### PR TITLE
Use redis-rb 3.3.x

### DIFF
--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency %q<fluentd>, [">= 0.10.0", "< 2"]
-  s.add_dependency %q<redis>, ["~> 2.2.2"]
+  s.add_dependency %q<redis>, ["~> 3.3.0"]
   s.add_development_dependency %q<rake>, [">= 11.3.0"]
   s.add_development_dependency %q<bundler>
   s.add_development_dependency %q<test-unit>, ["~> 3.1.0"]


### PR DESCRIPTION
fluent-plugin-redis is not affected redis-rb 3.x's breaking changes.
Let's upgrade redis ruby client library. :punch: