### PR TITLE
Fluentd v0.12 version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rvm:
   - 2.2
   - 2.3.3
 gemfile:
-  - gemfiles/fluentd_v0.10.gemfile
   - gemfiles/fluentd_v0.12.gemfile
-  - gemfiles/fluentd_v0.14.gemfile
-  - Gemfile
 before_install:
   - gem update bundler

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -3,10 +3,10 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-redis"
-  s.version     = "0.2.2"
+  s.version     = "0.2.3"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Yuki Nishijima", "Hiroshi Hatake", "Kenji Okimoto"]
-  s.date        = %q{2016-10-28}
+  s.date        = %q{2016-12-01}
   s.email       = ["mail@yukinishijima.net", "fluent@clear-code.com"]
   s.homepage    = "http://github.com/yuki24/fluent-plugin-redis"
   s.summary     = "Redis output plugin for Fluent"
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency %q<fluentd>, [">= 0.10.0", "< 2"]
+  s.add_dependency %q<fluentd>, ["~> 0.12.0"]
   s.add_dependency %q<redis>, ["~> 3.3.0"]
   s.add_development_dependency %q<rake>, [">= 11.3.0"]
   s.add_development_dependency %q<bundler>


### PR DESCRIPTION
`0.2.3` is mark as the last version of supporting Fluentd v0.12 or earlier.