### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2
   - 2.3.3
 gemfile:
-  - gemfiles/fluentd_v0.12.gemfile
+  - gemfiles/fluentd_v0.14.gemfile
+  - Gemfile
 before_install:
   - gem update bundler

--- a/README.rdoc
+++ b/README.rdoc
@@ -13,7 +13,7 @@ Then fluent automatically loads the plugin installed.
 == Configuration
 
     <match redis.**>
-      type redis
+      @type redis
 
       host localhost
       port 6379

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,16 @@
 
 fluent-plugin-redis is a fluent plugin to output to redis.
 
+== Requirements
+
+    |fluent-plugin-redis|     fluentd      |  ruby  |
+    |-------------------|------------------|--------|
+    |     >= 0.3.0      | >= 0.14.8        | >= 2.1 |
+    |     == 0.2.3      | ~> 0.12.0 *      | >= 1.9 |
+    |      < 0.2.3      | >= 0.10.0, < 2 * | >= 1.9 |
+
+    * May not support all future fluentd features
+
 == Installation
 
 What you have to do is only installing like this:
@@ -32,6 +42,12 @@ Then fluent automatically loads the plugin installed.
       # allow_duplicate_key true
     </match>
 
+
+=== Notice
+
+<em>insert_key_prefix</em>, <em>strftime_format</em>, and <em>allow_duplicate_key</em> are newly added config parameters.
+
+They can use v0.3.0 or later. To use this parameters, users must update Fluentd to v0.14 or later and this plugin to v0.3.0 or later.
 
 == Contributing to fluent-plugin-redis
  

--- a/README.rdoc
+++ b/README.rdoc
@@ -22,6 +22,14 @@ Then fluent automatically loads the plugin installed.
       db_number 0        # 0 is default
       # If requirepass is set, please specify this.
       # password hogefuga
+      # Users can set '${tag}' or ${tag[0]}.${tag[1]} or ...?
+      # insert_key_prefix '${tag}'
+      # Users can set strftime format.
+      # "%s" will be replaced into unixtime.
+      # "%Y%m%d.%H%M%S" will be replaced like as 20161202.112335.
+      # strftime_format "%s"
+      # Allow insert key duplicate. It will work as update values.
+      # allow_duplicate_key true
     </match>
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<bundler>
   s.add_development_dependency %q<test-unit>, ["~> 3.1.0"]
   s.add_development_dependency %q<appraisal>, ["~> 2.1.0"]
+  s.add_development_dependency "timecop", ["~> 0.8.0"]
 end

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-redis"
-  s.version     = "0.2.3"
+  s.version     = "0.3.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Yuki Nishijima", "Hiroshi Hatake", "Kenji Okimoto"]
   s.date        = %q{2016-12-01}

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency %q<fluentd>, ["~> 0.12.0"]
+  s.add_dependency %q<fluentd>, [">= 0.14.8", "< 2"]
   s.add_dependency %q<redis>, ["~> 3.3.0"]
   s.add_development_dependency %q<rake>, [">= 11.3.0"]
   s.add_development_dependency %q<bundler>

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<bundler>
   s.add_development_dependency %q<test-unit>, ["~> 3.1.0"]
   s.add_development_dependency %q<appraisal>, ["~> 2.1.0"]
-  s.add_development_dependency "timecop", ["~> 0.8.0"]
 end

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -22,10 +22,6 @@ module Fluent::Plugin
       config_set_default :chunk_keys, ['tag']
     end
 
-    def initialize
-      super
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -17,7 +17,7 @@ module Fluent::Plugin
     config_param :db_number, :integer, default: 0
     config_param :password, :string, default: nil, secret: true
     config_param :insert_key_prefix, :string, default: "${tag}"
-    config_param :strtime_format, :string, default: "%s"
+    config_param :strftime_format, :string, default: "%s"
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -78,7 +78,7 @@ module Fluent::Plugin
 
     def expand_placeholders(metadata)
       tag = extract_placeholders(@insert_key_prefix, metadata)
-      time = extract_placeholders(@strtime_format, metadata)
+      time = extract_placeholders(@strftime_format, metadata)
       return tag, time
     end
   end

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -33,6 +33,8 @@ module Fluent::Plugin
       if conf.has_key?('namespace')
         log.warn "namespace option has been removed from fluent-plugin-redis 0.1.3. Please add or remove the namespace '#{conf['namespace']}' manually."
       end
+      raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
+      raise Fluent::ConfigError, "'time' in chunk_keys is required." if not @chunk_key_time
     end
 
     def start

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -78,7 +78,7 @@ module Fluent::Plugin
             end
           }
         else
-          chunk.msgpack_each do |_tag, _time, record|
+          chunk.each do |_tag, _time, record|
             @redis.mapped_hmset "#{tag}", record
           end
         end

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -12,10 +12,10 @@ module Fluent::Plugin
 
     attr_reader :redis
 
-    config_param :host, :string, :default => 'localhost'
-    config_param :port, :integer, :default => 6379
-    config_param :db_number, :integer, :default => 0
-    config_param :password, :string, :default => nil, :secret => true
+    config_param :host, :string, default: 'localhost'
+    config_param :port, :integer, default: 6379
+    config_param :db_number, :integer, default: 0
+    config_param :password, :string, default: nil, secret: true
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -35,10 +35,10 @@ module Fluent::Plugin
       super
 
       options = {
-        :host => @host,
-        :port => @port,
-        :thread_safe => true,
-        :db => @db_number
+        host: @host,
+        port: @port,
+        thread_safe: true,
+        db: @db_number
       }
       options[:password] = @password if @password
 

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
         unless @allow_duplicate_key
           chunk.open { |io|
             begin
-              MessagePack::Unpacker.new(io).each.each_with_index { |record, index|
+              MessagePack::Unpacker.new(io).each.with_index { |record, index|
                 identifier = [tag, time].join(".")
                 @redis.mapped_hmset "#{identifier}.#{index}", record[2]
               }

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -1,3 +1,5 @@
+require 'redis'
+require 'msgpack'
 require 'fluent/plugin/output'
 
 module Fluent::Plugin
@@ -22,8 +24,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'redis'
-      require 'msgpack'
     end
 
     def configure(conf)

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -17,7 +17,7 @@ module Fluent::Plugin
     config_param :db_number, :integer, default: 0
     config_param :password, :string, default: nil, secret: true
     config_param :insert_key_prefix, :string, default: "${tag}"
-    config_param :strtime_format, :string, default: "%Y/%m/%d %H:%M:%S.%N%z"
+    config_param :strtime_format, :string, default: "%s"
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -78,8 +78,7 @@ module Fluent::Plugin
 
     def expand_placeholders(metadata)
       tag = extract_placeholders(@insert_key_prefix, metadata)
-      strtime = extract_placeholders(@strtime_format, metadata)
-      time = Time.parse(strtime).to_i rescue ""
+      time = extract_placeholders(@strtime_format, metadata)
       return tag, time
     end
   end

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -20,11 +20,6 @@ module Fluent::Plugin
       config_set_default :chunk_keys, ['tag']
     end
 
-    # To support log_level option implemented by Fluentd v0.10.43
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
     def initialize
       super
       require 'redis'

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -1,9 +1,12 @@
 require 'redis'
 require 'msgpack'
+require 'fluent/msgpack_factory'
 require 'fluent/plugin/output'
 
 module Fluent::Plugin
   class RedisOutput < Output
+    include Fluent::MessagePackFactory::Mixin
+
     Fluent::Plugin.register_output('redis', self)
 
     helpers :compat_parameters, :inject
@@ -71,7 +74,7 @@ module Fluent::Plugin
         unless @allow_duplicate_key
           chunk.open { |io|
             begin
-              MessagePack::Unpacker.new(io).each.with_index { |record, index|
+              msgpack_unpacker(io).each.with_index { |record, index|
                 identifier = [tag, time].join(".")
                 @redis.mapped_hmset "#{identifier}.#{index}", record[2]
               }

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -69,11 +69,11 @@ class FileOutputTest < Test::Unit::TestCase
 
     def test_write_with_custom_strftime_format
       d = create_driver CONFIG + %[
-        strftime_format %Y%m%d
+        strftime_format "%Y%m%d.%H%M%S"
       ]
-      now = Time.parse("2011-01-02 13:14:00 UTC")
+      now = Time.parse("2011-01-02 13:14:00 UTC").localtime
       time = Fluent::EventTime.from_time(now)
-      strtime = now.strftime("%Y%m%d")
+      strtime = now.strftime("%Y%m%d.%H%M%S")
       d.run(default_tag: 'test') do
         d.feed(time, {"a"=>4})
         d.feed(time, {"a"=>5})

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -3,7 +3,6 @@ require 'fluent/test/helpers'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_redis'
 require 'fluent/time' # Fluent::TimeFormatter
-require 'timecop'
 
 class FileOutputTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
@@ -95,10 +94,6 @@ class FileOutputTest < Test::Unit::TestCase
   end
 
   class WriteTest < self
-    def setup
-      Timecop.freeze(Time.parse("2011-01-02 13:14:00 UTC"))
-    end
-
     def test_write
       d = create_driver
       time = event_time("2011-01-02 13:14:00 UTC")
@@ -151,10 +146,6 @@ class FileOutputTest < Test::Unit::TestCase
       end
 
       assert_equal "7", d.instance.redis.hget("test.duplicate", "a")
-    end
-
-    def teardown
-      Timecop.return
     end
   end
 end

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -7,14 +7,16 @@ require 'timecop'
 class FileOutputTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
 
+  CONFIG = %[
+    host localhost
+    port 6379
+    db_number 1
+  ]
+
   def setup
     Fluent::Test.setup
 
-    @d = create_driver %[
-      host localhost
-      port 6379
-      db_number 1
-    ]
+    @d = create_driver
     @time = event_time("2011-01-02 13:14:15 UTC")
   end
 
@@ -30,10 +32,7 @@ class FileOutputTest < Test::Unit::TestCase
   end
 
   def test_configure_with_password
-    d = create_driver %[
-      host localhost
-      port 6379
-      db_number 1
+    d = create_driver CONFIG + %[
       password testpass
     ]
     assert_equal 'localhost', d.instance.host
@@ -52,11 +51,7 @@ class FileOutputTest < Test::Unit::TestCase
   class WriteTest < self
     def setup
       Timecop.freeze(Time.parse("2011-01-02 13:14:15 UTC"))
-      @d = create_driver %[
-        host localhost
-        port 6379
-        db_number 1
-      ]
+      @d = create_driver
     end
 
     def test_write

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -54,7 +54,6 @@ class FileOutputTest < Test::Unit::TestCase
       @d.feed(@time, {"a"=>3})
     end
 
-
     assert_equal "2", @d.instance.redis.hget("test.#{@time}.0", "a")
     assert_equal "3", @d.instance.redis.hget("test.#{@time}.1", "a")
   end

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -129,9 +129,8 @@ class FileOutputTest < Test::Unit::TestCase
       d = create_driver CONFIG + %[
         strftime_format "%Y%m%d.%H%M%S"
       ]
-      now = Time.parse("2011-01-02 13:14:00 UTC").localtime
-      time = Fluent::EventTime.from_time(now)
-      strtime = now.strftime("%Y%m%d.%H%M%S")
+      time = event_time("2011-01-02 13:14:00 UTC")
+      strtime = Time.at(time.to_r).strftime("%Y%m%d.%H%M%S")
       d.run(default_tag: 'test') do
         d.feed(time, {"a"=>4})
         d.feed(time, {"a"=>5})

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -44,6 +44,21 @@ class FileOutputTest < Test::Unit::TestCase
     assert_equal 'testpass', d.instance.password
   end
 
+  def test_configure_without_tag_chunk_key
+    config = config_element('ROOT', '', {
+                              "host" => "localhost",
+                              "port" =>  6379,
+                              "db_number" => 1,
+                            }, [
+                              config_element('buffer', 'time', {
+                                               'chunk_keys' => 'time',
+                                             })
+                            ])
+    assert_raise Fluent::ConfigError do
+      create_driver(config)
+    end
+  end
+
   def test_format
     @d.run(default_tag: 'test') do
       @d.feed(@time, {"a"=>1})

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -101,7 +101,7 @@ class FileOutputTest < Test::Unit::TestCase
 
     def test_write
       d = create_driver
-      time = Fluent::Engine.now
+      time = event_time("2011-01-02 13:14:00 UTC")
       d.run(default_tag: 'test') do
         d.feed(time, {"a"=>2})
         d.feed(time, {"a"=>3})
@@ -115,7 +115,7 @@ class FileOutputTest < Test::Unit::TestCase
       d = create_driver CONFIG + %[
         insert_key_prefix "${tag[1]}.${tag[2]}"
       ]
-      time = Fluent::Engine.now
+      time = event_time("2011-01-02 13:14:00 UTC")
       d.run(default_tag: 'prefix.insert.test') do
         d.feed(time, {"a"=>2})
         d.feed(time, {"a"=>3})

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -68,6 +68,20 @@ class FileOutputTest < Test::Unit::TestCase
       assert_equal "3", d.instance.redis.hget("test.#{time}.1", "a")
     end
 
+    def test_write_with_insert_key_prefix
+      d = create_driver CONFIG + %[
+        insert_key_prefix "${tag[1]}.${tag[2]}"
+      ]
+      time = Fluent::Engine.now.to_i
+      d.run(default_tag: 'prefix.insert.test') do
+        d.feed(time, {"a"=>2})
+        d.feed(time, {"a"=>3})
+      end
+
+      assert_equal "2", d.instance.redis.hget("insert.test.#{time}.0", "a")
+      assert_equal "3", d.instance.redis.hget("insert.test.#{time}.1", "a")
+    end
+
     def test_write_with_custom_strftime_format
       d = create_driver CONFIG + %[
         strftime_format "%Y%m%d.%H%M%S"

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -50,19 +50,19 @@ class FileOutputTest < Test::Unit::TestCase
 
   class WriteTest < self
     def setup
-      Timecop.freeze(Time.parse("2011-01-02 13:14:15 UTC"))
+      Timecop.freeze(Time.parse("2011-01-02 13:14:00 UTC"))
       @d = create_driver
     end
 
     def test_write
-      time = Fluent::Engine.now
+      time = Fluent::Engine.now.to_i
       @d.run(default_tag: 'test') do
         @d.feed(time, {"a"=>2})
         @d.feed(time, {"a"=>3})
       end
 
-      assert_equal "2", @d.instance.redis.hget(@d.instance.redis.keys[0], "a")
-      assert_equal "3", @d.instance.redis.hget(@d.instance.redis.keys[1], "a")
+      assert_equal "2", @d.instance.redis.hget("test.#{time}.0", "a")
+      assert_equal "3", @d.instance.redis.hget("test.#{time}.1", "a")
     end
 
     def teardown

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -29,6 +29,8 @@ class FileOutputTest < Test::Unit::TestCase
     assert_equal 6379, @d.instance.port
     assert_equal 1, @d.instance.db_number
     assert_nil @d.instance.password
+    assert_equal '${tag}', @d.instance.insert_key_prefix
+    assert_equal '%s', @d.instance.strftime_format
   end
 
   def test_configure_with_password

--- a/test/plugin/test_out_redis.rb
+++ b/test/plugin/test_out_redis.rb
@@ -101,7 +101,7 @@ class FileOutputTest < Test::Unit::TestCase
 
     def test_write
       d = create_driver
-      time = Fluent::Engine.now.to_i
+      time = Fluent::Engine.now
       d.run(default_tag: 'test') do
         d.feed(time, {"a"=>2})
         d.feed(time, {"a"=>3})
@@ -115,7 +115,7 @@ class FileOutputTest < Test::Unit::TestCase
       d = create_driver CONFIG + %[
         insert_key_prefix "${tag[1]}.${tag[2]}"
       ]
-      time = Fluent::Engine.now.to_i
+      time = Fluent::Engine.now
       d.run(default_tag: 'prefix.insert.test') do
         d.feed(time, {"a"=>2})
         d.feed(time, {"a"=>3})


### PR DESCRIPTION
We should consider  this proposal and accept/reject it before merging this:

> Here are some of the keys stored:

> user_pref.foo.1433835158.1

> Is there a way to just store user_pref.foo (I want a insert or update functionality)?

ref: #2 

Currently, I've implemented it and add more flexibility configuration which depends on v0.14's expand placeholders.