### PR TITLE
Remove needless begin rescue block

### DIFF
--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -71,14 +71,10 @@ module Fluent::Plugin
       @redis.pipelined {
         unless @allow_duplicate_key
           stream = chunk.to_msgpack_stream
-          begin
-            @unpacker.feed_each(stream).with_index { |record, index|
-              identifier = [tag, time].join(".")
-              @redis.mapped_hmset "#{identifier}.#{index}", record[2]
-            }
-          rescue EOFError
-            # EOFError always occured when reached end of chunk.
-          end
+          @unpacker.feed_each(stream).with_index { |record, index|
+            identifier = [tag, time].join(".")
+            @redis.mapped_hmset "#{identifier}.#{index}", record[2]
+          }
         else
           chunk.each do |_tag, _time, record|
             @redis.mapped_hmset "#{tag}", record


### PR DESCRIPTION
`unpacker#feed_each` returns Enumerator.
It doesn't cause `EOFError` when traversing their elements.