### PR TITLE
Prepare multi workers feature

### DIFF
--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -69,6 +69,10 @@ module Fluent::Plugin
       true
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def write(chunk)
       tag, time = expand_placeholders(chunk.metadata)
       @redis.pipelined {


### PR DESCRIPTION
We can obtain each of plugin's worker id with `#fluentd_worker_id`:
https://github.com/fluent/fluentd/commit/047fade1db3432f31c2cb95b400d046928cb38f9#diff-a6ec17a82b093259c91368ae96896493R47

Could you review this PR, @okkez ?