### PR TITLE
Pass chunk directly into builtin placeholders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4.3
-  - 2.5.0
+  - 2.4
+  - 2.5.3
+  - 2.6.0
 gemfile:
   - gemfiles/fluentd_v0.14.gemfile
   - Gemfile

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency %q<fluentd>, [">= 0.14.8", "< 2"]
+  s.add_dependency %q<fluentd>, [">= 0.14.22", "< 2"]
   s.add_dependency %q<redis>, ["~> 3.3.0"]
   s.add_development_dependency %q<rake>, [">= 11.3.0"]
   s.add_development_dependency %q<bundler>

--- a/fluent-plugin-redis.gemspec
+++ b/fluent-plugin-redis.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-redis"
-  s.version     = "0.3.3"
+  s.version     = "0.3.4"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Yuki Nishijima", "Hiroshi Hatake", "Kenji Okimoto"]
   s.date        = %q{2017-04-17}

--- a/lib/fluent/plugin/out_redis.rb
+++ b/lib/fluent/plugin/out_redis.rb
@@ -74,7 +74,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      tag, time = expand_placeholders(chunk.metadata)
+      tag, time = expand_placeholders(chunk)
       @redis.pipelined {
         unless @allow_duplicate_key
           stream = chunk.to_msgpack_stream
@@ -102,9 +102,9 @@ module Fluent::Plugin
 
     private
 
-    def expand_placeholders(metadata)
-      tag = extract_placeholders(@insert_key_prefix, metadata)
-      time = extract_placeholders(@strftime_format, metadata)
+    def expand_placeholders(chunk)
+      tag = extract_placeholders(@insert_key_prefix, chunk)
+      time = extract_placeholders(@strftime_format, chunk)
       return tag, time
     end
   end


### PR DESCRIPTION
We should use `expand_placeholders(chunk)` instead of `expand_placeholders(chunk.metadata)`.