### PR TITLE
Gemfile: use HTTPS for the RubyGems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in fluent-plugin-redis.gemspec
 gemspec


### PR DESCRIPTION
The gem source was declared as `http://rubygems.org`, so `bundle install` fetched dependency metadata and gem archives over plaintext HTTP. That connection is neither encrypted nor authenticated, letting an on-path attacker substitute the index response and serve arbitrary gem code, which Bundler unpacks and loads on developer machines and in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
